### PR TITLE
SWIK-1692 hashtag tweet streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ node_modules
 .node_repl_history
 
 .coveralls.yml
+config.tpl
+config.json

--- a/application/package.json
+++ b/application/package.json
@@ -31,8 +31,10 @@
     "hapi-swagger": "^7.6.0",
     "inert": "^4.2.0",
     "joi": "^10.6.0",
+    "lodash": "^4.17.4",
     "node-static": "0.7.9",
     "socket.io": "2.0.3",
+    "twitter": "^1.7.1",
     "vision": "^4.1.0"
   },
   "engines": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,5 @@ template:
     - VIRTUAL_HOST=signalingservice.experimental.slidewiki.org
     - LETSENCRYPT_HOST=signalingservice.experimental.slidewiki.org
     - LETSENCRYPT_EMAIL=meissner@informatik.uni-leipzig.de
+  volumes:
+    - /data/slidewiki-deployment/docker-compose/twitterConfig_experimental.json:/nodeApp/config.json:ro


### PR DESCRIPTION
I've added a method to receive twitter tweets that match the requested hashtags. These are than delivered to the peer that requested to follow these hashtags (in platform code: only the presenter).
Hashtags for the imported twitter package must be formatted like "#abc #xyz #bde".

I have no idea if this is the right method to use the twitter streaming API. I am currently opening a new stream for each room that wants to follow twitter (by default: each room). Or whether it should be:
1) cancel current twitter stream, but save hashtags
2) open a new stream that include the saved hashtags and new hashtags (using stream operators like OR and AND).

Documentation is very sparse at [twitter streams documentation](https://developer.twitter.com/en/docs/tutorials/consuming-streaming-data).

To get this to work, twitter credentials are needed. They are located at my laptop and also on our experimental server (same location as user-service credentials).